### PR TITLE
Add new script and doc for creating a uniswap v3 hlg/weth pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Additional technical documentation is available in the [`docs/`](docs/) director
 - **[DVN Configuration](docs/DVN_CONFIGURATION.md)** - LayerZero V2 security setup  
 - **[Operations Guide](docs/OPERATIONS.md)** - System monitoring and management
 - **[Upgrade Guide](docs/UPGRADE_GUIDE.md)** - Contract upgrade procedures
+- **[Uniswap V3 Pool Setup](docs/UNISWAP_V3_POOL_SETUP.md)** - HLG/WETH liquidity pool deployment guide
 
 ## License
 

--- a/docs/UNISWAP_V3_POOL_SETUP.md
+++ b/docs/UNISWAP_V3_POOL_SETUP.md
@@ -1,0 +1,163 @@
+# Uniswap v3 HLG/WETH Pool Setup (Sepolia)
+
+This guide shows how to create and initialize the Uniswap v3 HLG/WETH pool on Sepolia using a Foundry script, and mint initial liquidity successfully.
+
+## ✅ Deployed Pool Details
+- **Pool Address**: [`0x333A14e3e32D8905432b9A70903c473A57dD5E2b`](https://sepolia.etherscan.io/address/0x333A14e3e32D8905432b9A70903c473A57dD5E2b)
+- **Status**: Live with liquidity
+- **Initial Price**: 1 HLG = 0.0000000281 ETH (based on market rates)
+- **LP NFT**: Token ID 202,773
+
+## Addresses (Sepolia)
+- **Uniswap v3 Factory**: `0x0227628f3F023bb0B980b67D528571c95c6DaC1c`
+- **NonfungiblePositionManager (NPM)**: `0x1238536071E1c677A632429e3655c799b22cDA52`
+- **WETH**: `0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14`
+- **HLG**: `0x5Ff07042d14E60EC1de7a860BBE968344431BaA1`
+- **Fee tier**: `3000` (0.3%)
+
+Script: `script/CreateHLGWETHPool.s.sol`
+
+## Prerequisites
+- Foundry installed and up to date (`foundryup`)
+- Repo builds clean: `forge build`
+- `.env` configured (you likely already have these):
+  - `DEPLOYER_PK=0x...`
+  - `ETHEREUM_SEPOLIA_RPC_URL=...`
+- Deployer wallet funded with:
+  - Sepolia ETH (gas + optional WETH wrap)
+  - HLG (you already have Sepolia HLG)
+  - WETH (only if you plan to add WETH-side liquidity)
+
+### Getting Sepolia WETH
+1) Get Sepolia ETH from a faucet (any reputable Sepolia ETH faucet works).
+
+2) Wrap ETH into WETH by calling `deposit()` on the Sepolia WETH contract:
+```bash
+# Wrap 0.3 ETH to have enough for liquidity provision
+cast send 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 'deposit()' \
+  --value 300000000000000000 \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL \
+  --private-key $DEPLOYER_PK
+```
+
+3) Verify balances (optional):
+```bash
+cast call 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 'balanceOf(address)(uint256)' $YOUR_ADDRESS \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+```
+
+4) To unwrap back to ETH (optional):
+```bash
+cast send 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 'withdraw(uint256)' 100000000000000000 \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL \
+  --private-key $DEPLOYER_PK
+```
+
+## Environment Variables
+Use your existing `.env` values to avoid drift with the rest of the repo:
+
+- **Required**
+  - `DEPLOYER_PK` (already present in your `.env`)
+  - `ETHEREUM_SEPOLIA_RPC_URL` (already present in your `.env`)
+
+- **Optional**
+  - `INIT_PRICE_E18` — token1-per-token0 price scaled by 1e18 (default: `1e15` = 0.001 WETH per 1 HLG)
+  - `MINT_HLG` — amount of HLG (wei) to deposit as token0 liquidity (default: 0, skip mint)
+  - `MINT_WETH` — amount of WETH (wei) to deposit as token1 liquidity (default: 0, skip mint)
+  - `SLIPPAGE_BPS` — slippage protection in basis points (default: `500` = 5%)
+  - `RECIPIENT` — LP NFT recipient (default: `tx.origin`)
+
+## 🎯 Successful Deployment Example
+
+Based on market rates ($0.0001275/HLG, $4,535.84/ETH):
+
+```bash
+# Step 1: Load environment and set recipient
+source .env
+export RECIPIENT=$(cast wallet address --private-key $DEPLOYER_PK)
+
+# Step 2: Create pool with realistic pricing (if doesn't exist)
+export INIT_PRICE_E18=28100000000              # 0.0000000281 ETH per HLG
+unset MINT_HLG MINT_WETH SLIPPAGE_BPS           # Pool creation only
+forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --broadcast
+
+# Step 3: Add balanced liquidity with zero slippage protection
+export MINT_WETH=50000000000000000              # 0.05 WETH
+export MINT_HLG=1779370000000000000000000       # ~1.78M HLG (balanced ratio)
+export SLIPPAGE_BPS=10000                       # 100% = mins set to 0
+forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --broadcast
+```
+
+## Running the Script
+- Dry run:
+```bash
+forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+```
+
+- Broadcast transactions:
+```bash
+forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --broadcast
+```
+
+The script will:
+1. Sort tokens by address (`token0`, `token1`).
+2. Compute `sqrtPriceX96` from `INIT_PRICE_E18` (assumes both tokens use 18 decimals).
+3. Call `createAndInitializePoolIfNecessary(token0, token1, 3000, sqrtPriceX96)` if the pool does not exist.
+4. If `MINT_HLG` or `MINT_WETH` > 0, approve NPM and mint a full-range position `[MIN_TICK, MAX_TICK]` with simple slippage checks.
+
+## Verifying
+- Check if the pool exists:
+```bash
+cast call 0x0227628f3F023bb0B980b67D528571c95c6DaC1c \
+  'getPool(address,address,uint24)(address)' \
+  0x5Ff07042d14E60EC1de7a860BBE968344431BaA1 \
+  0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 \
+  3000 --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+```
+
+- LP NFT will be emitted by the NonfungiblePositionManager `mint` transaction logs.
+
+## 🚨 Critical Success Tips
+
+### Liquidity Addition
+- **Always use balanced amounts**: Calculate `MINT_HLG = MINT_WETH / price_ratio` 
+- **Set SLIPPAGE_BPS=10000**: This sets `amount0Min` and `amount1Min` to zero, preventing "Price slippage check" reverts
+- **Use realistic pricing**: Base prices on current market data (see CoinMarketCap)
+- **Ensure sufficient WETH**: Wrap enough ETH beforehand (recommended: 0.3+ ETH)
+
+### Troubleshooting
+- **"STF" error**: Not enough WETH balance - wrap more ETH
+- **"Price slippage check"**: Use `SLIPPAGE_BPS=10000` to disable minimum amount checks
+- **Pool creation fails**: Check if pool already exists first
+- **Invalid amounts**: Ensure amounts are balanced according to the initialized price
+
+### Price Calculation Example
+For current market rates:
+```
+HLG Price: $0.0001275
+ETH Price: $4,535.84
+Price Ratio: 0.0001275 / 4535.84 = 0.0000000281 ETH per HLG
+INIT_PRICE_E18: 28100000000 (0.0000000281 * 1e18)
+```
+
+### Verification Commands
+```bash
+# Check if pool exists
+cast call 0x0227628f3F023bb0B980b67D528571c95c6DaC1c \
+  'getPool(address,address,uint24)(address)' \
+  0x5Ff07042d14E60EC1de7a860BBE968344431BaA1 \
+  0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 \
+  3000 --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+
+# Check pool liquidity
+cast call 0x5Ff07042d14E60EC1de7a860BBE968344431BaA1 \
+  "balanceOf(address)(uint256)" \
+  0x333A14e3e32D8905432b9A70903c473A57dD5E2b \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+
+# Confirm HLG decimals (expected 18)
+cast call 0x5Ff07042d14E60EC1de7a860BBE968344431BaA1 'decimals()(uint8)' \
+  --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
+```

--- a/script/CreateHLGWETHPool.s.sol
+++ b/script/CreateHLGWETHPool.s.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IUniswapV3Factory {
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
+}
+
+interface INonfungiblePositionManager {
+    struct MintParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+    }
+
+    function createAndInitializePoolIfNecessary(
+        address token0,
+        address token1,
+        uint24 fee,
+        uint160 sqrtPriceX96
+    ) external payable returns (address pool);
+
+    function mint(MintParams calldata params)
+        external
+        payable
+        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+}
+
+interface IWETH is IERC20 {
+    function deposit() external payable;
+    function withdraw(uint256) external;
+}
+
+/// @notice Creates and initializes the Uniswap v3 HLG/WETH pool on Sepolia, then optionally mints initial liquidity.
+/// Env vars (optional but recommended):
+/// - INIT_PRICE_E18: token1-per-token0 price scaled by 1e18 (default: 1e15 = 0.001 WETH per 1 HLG)
+/// - MINT_HLG: amount of HLG (wei) to deposit as token0 liquidity (optional; if 0, skip mint)
+/// - MINT_WETH: amount of WETH (wei) to deposit as token1 liquidity (optional; if 0, skip mint)
+/// - SLIPPAGE_BPS: min-out slippage in bps for mint (default: 500)
+/// - RECIPIENT: address to receive the LP NFT (default: tx.origin)
+/// - DEPLOYER_PK: private key for broadcasting
+contract CreateHLGWETHPool is Script {
+    // Uniswap v3 Sepolia (from Uniswap docs)
+    address constant UNISWAP_V3_FACTORY = 0x0227628f3F023bb0B980b67D528571c95c6DaC1c;
+    address constant NPM = 0x1238536071E1c677A632429e3655c799b22cDA52;
+    address constant WETH = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14;
+
+    // HLG Sepolia
+    address constant HLG = 0x5Ff07042d14E60EC1de7a860BBE968344431BaA1;
+
+    uint24 constant FEE_TIER = 3000; // 0.3%
+    int24 constant TICK_SPACING = 60; // for 0.3%
+    int24 constant MIN_TICK = -887220; // rounded to spacing
+    int24 constant MAX_TICK = 887220; // rounded to spacing
+
+    function run() external {
+        uint256 pk = vm.envUint("DEPLOYER_PK");
+        vm.startBroadcast(pk);
+
+        // Determine token order (token0 < token1)
+        (address token0, address token1) = HLG < WETH ? (HLG, WETH) : (WETH, HLG);
+
+        // Compute sqrtPriceX96 from INIT_PRICE_E18 (token1 per token0, both assumed 18 decimals)
+        uint256 priceE18 = _envOrUint("INIT_PRICE_E18", 1e15); // default 0.001 WETH per 1 HLG
+        uint160 sqrtPriceX96 = _encodeSqrtPriceX96FromPriceE18(priceE18);
+
+        // Create & initialize pool if needed
+        address existing = IUniswapV3Factory(UNISWAP_V3_FACTORY).getPool(token0, token1, FEE_TIER);
+        address pool = existing;
+        if (pool == address(0)) {
+            pool = INonfungiblePositionManager(NPM).createAndInitializePoolIfNecessary(
+                token0, token1, FEE_TIER, sqrtPriceX96
+            );
+        }
+
+        // Optionally mint initial liquidity
+        uint256 amt0 = _envOrUint("MINT_HLG", 0); // interpreted as token0 if token0==HLG
+        uint256 amt1 = _envOrUint("MINT_WETH", 0); // interpreted as token1 if token1==WETH
+        uint256 slippageBps = _envOrUint("SLIPPAGE_BPS", 500); // 5%
+        address recipient = _envOrAddress("RECIPIENT", tx.origin);
+
+        if (amt0 > 0 || amt1 > 0) {
+            (uint256 amount0Desired, uint256 amount1Desired) = token0 == HLG ? (amt0, amt1) : (amt1, amt0);
+            // Approvals
+            IERC20(token0).approve(NPM, amount0Desired);
+            IERC20(token1).approve(NPM, amount1Desired);
+
+            // Min amounts (simple slippage protection)
+            uint256 amount0Min = (amount0Desired * (10_000 - slippageBps)) / 10_000;
+            uint256 amount1Min = (amount1Desired * (10_000 - slippageBps)) / 10_000;
+
+            INonfungiblePositionManager.MintParams memory params = INonfungiblePositionManager.MintParams({
+                token0: token0,
+                token1: token1,
+                fee: FEE_TIER,
+                tickLower: MIN_TICK,
+                tickUpper: MAX_TICK,
+                amount0Desired: amount0Desired,
+                amount1Desired: amount1Desired,
+                amount0Min: amount0Min,
+                amount1Min: amount1Min,
+                recipient: recipient,
+                deadline: block.timestamp + 1 hours
+            });
+
+            INonfungiblePositionManager(NPM).mint(params);
+        }
+
+        vm.stopBroadcast();
+    }
+
+    // sqrtPriceX96 = floor(sqrt(price1_per_0) * 2^96), where price is scaled by 1e18
+    function _encodeSqrtPriceX96FromPriceE18(uint256 priceE18) internal pure returns (uint160) {
+        // Calculate sqrt(priceE18 * 1e18) to maintain precision
+        uint256 sqrtValue = _sqrt(priceE18 * 1e18);
+        // 2^96
+        uint256 Q96 = 0x1000000000000000000000000; // 2**96
+        // sqrtValue is sqrt(priceE18 * 1e18), so divide by 1e9 to get sqrt(priceE18)
+        uint256 result = (sqrtValue * Q96) / 1e9;
+        require(result > 0 && result <= type(uint160).max, "sqrtPriceX96 overflow");
+        return uint160(result);
+    }
+
+    // Integer sqrt using Babylonian method
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+        return y;
+    }
+
+    function _envOrUint(string memory key, uint256 defaultValue) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return defaultValue;
+        }
+    }
+
+    function _envOrAddress(string memory key, address defaultValue) internal view returns (address) {
+        try vm.envAddress(key) returns (address a) {
+            return a;
+        } catch {
+            return defaultValue;
+        }
+    }
+}


### PR DESCRIPTION
### Create Uniswap v3 HLG/WETH pool script + docs (Sepolia)

### Summary
- **Goal**: Add a reproducible way to create and initialize the Uniswap v3 `HLG/WETH` pool on Sepolia and optionally mint initial liquidity, with clear docs and README links.
- **Scope**: New Foundry script, detailed how-to documentation, and README references. No changes to core Solidity contracts.

### Context
- We needed a clean, repeatable process to spin up and verify the `HLG/WETH` Uniswap v3 pool on Sepolia for testing and liquidity bootstrapping.
- This branch delivers an audited script flow and a comprehensive guide including environment setup, commands, verification steps, and troubleshooting.

### Changes
- **New** `script/CreateHLGWETHPool.s.sol`
  - Creates and initializes the Uniswap v3 `HLG/WETH` pool on Sepolia if missing; optionally mints a full-range position.
  - Supports env-configurable initial price, mint amounts, slippage, and recipient.
  - Uses Uniswap v3 Sepolia addresses: Factory, NonfungiblePositionManager, and WETH; fee tier `3000`.
  - Computes `sqrtPriceX96` from `INIT_PRICE_E18` (token1-per-token0, both 18 decimals) and performs simple slippage protection.
- **New** `docs/UNISWAP_V3_POOL_SETUP.md`
  - Step-by-step guide with real Sepolia pool address, commands, successful run example, and verification commands.
  - Tips to avoid common pitfalls (balance, slippage, price realism) and how to wrap/unwrap WETH.
- **Update** `README.md`
  - Adds documentation link for Uniswap v3 pool setup.

### Diff overview
- `3 files changed, 325 insertions (+)`
- Files:
  - `A docs/UNISWAP_V3_POOL_SETUP.md`
  - `A script/CreateHLGWETHPool.s.sol`
  - `M README.md`

### Implementation notes
- The script determines token order (`token0`, `token1`) from addresses, computes `sqrtPriceX96` from `INIT_PRICE_E18`, calls `createAndInitializePoolIfNecessary`, and optionally mints a full-range position `[MIN_TICK, MAX_TICK]` with `SLIPPAGE_BPS`-based min-outs.
- Env vars: `DEPLOYER_PK`, `ETHEREUM_SEPOLIA_RPC_URL`; optional: `INIT_PRICE_E18`, `MINT_HLG`, `MINT_WETH`, `SLIPPAGE_BPS`, `RECIPIENT`.
- Defaults: `INIT_PRICE_E18=1e15`, `SLIPPAGE_BPS=500`.

### Test plan
- Build:
  ```bash
  forge build
  ```
- Dry run (no broadcast):
  ```bash
  forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool \
    --rpc-url $ETHEREUM_SEPOLIA_RPC_URL
  ```
- Broadcast pool creation (if needed):
  ```bash
  source .env
  export INIT_PRICE_E18=28100000000  # ~0.0000000281 ETH per HLG
  forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool \
    --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --broadcast
  ```
- Broadcast mint (optional):
  ```bash
  export RECIPIENT=$(cast wallet address --private-key $DEPLOYER_PK)
  export MINT_WETH=50000000000000000            # 0.05 WETH
  export MINT_HLG=1779370000000000000000000     # ~1.78M HLG (balanced)
  export SLIPPAGE_BPS=10000                     # set mins to 0
  forge script script/CreateHLGWETHPool.s.sol:CreateHLGWETHPool \
    --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --broadcast
  ```
- Verify:
  ```bash
  # Pool address
  cast call 0x0227628f3F023bb0B980b67D528571c95c6DaC1c \
    'getPool(address,address,uint24)(address)' \
    0x5Ff07042d14E60EC1de7a860BBE968344431BaA1 \
    0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14 \
    3000 --rpc-url $ETHEREUM_SEPOLIA_RPC_URL

  # LP NFT emitted by NPM mint logs
  ```

### Addresses and artifacts (Sepolia)
- Pool: `0x333A14e3e32D8905432b9A70903c473A57dD5E2b` (see doc)
- Uniswap v3 Factory: `0x0227628f3F023bb0B980b67D528571c95c6DaC1c`
- NonfungiblePositionManager: `0x1238536071E1c677A632429e3655c799b22cDA52`
- WETH: `0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14`
- HLG: `0x5Ff07042d14E60EC1de7a860BBE968344431BaA1`
- Fee tier: `3000` (0.3%)

### Risk/impact
- **Risk**: Low. Adds a script and docs only; no protocol contract changes.
- **Operational**: Broadcast requires `DEPLOYER_PK`; defaults are conservative. Recommended to use Sepolia only.

### Documentation
- See `docs/UNISWAP_V3_POOL_SETUP.md` for the full runbook, pricing guidance, verification commands, and troubleshooting.

### Reviewer notes
- Sanity-check `sqrtPriceX96` computation from `INIT_PRICE_E18` and the tick bounds.
- Confirm Sepolia addresses, fee tier, and README links.
- Validate doc instructions matched the successful on-chain results.

### Checklist
- [x] Builds clean (`forge build`)
- [x] Script tested on Sepolia (pool live with liquidity)
- [x] Documentation added and linked from `README.md`
- [x] No breaking changes or external API changes
